### PR TITLE
Added a !null check for ItemsSource and SelectedItem before existence…

### DIFF
--- a/src/FreshEssentials/Controls/BindablePicker.cs
+++ b/src/FreshEssentials/Controls/BindablePicker.cs
@@ -46,13 +46,16 @@ namespace FreshEssentials
             set
             {
                 base.SetValue(BindablePicker.SelectedItemProperty, value);
-                if (ItemsSource.Contains(SelectedItem))
+                if (ItemsSource != null && SelectedItem != null)
                 {
-                    SelectedIndex = ItemsSource.IndexOf(SelectedItem);
-                }
-                else
-                {
-                    SelectedIndex = -1;
+                    if (ItemsSource.Contains(SelectedItem))
+                    {
+                        SelectedIndex = ItemsSource.IndexOf(SelectedItem);
+                    }
+                    else
+                    {
+                        SelectedIndex = -1;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Added a !null check for ItemsSource and SelectedItem before existence checking to resolve a weird NullReference exception I keep getting when binding to a list that's asynchronously populated. The exception pops up when navigating between pages multiple times. I'm not sure if it's due to how I'm asynchronously grabbing the list, but this fixed it for me.

`<fe:BindablePicker ItemsSource="{Binding Projects, Mode=TwoWay}" DisplayProperty="Name" Title="Select a Project..." SelectedItem="{Binding SelectedProject}" />`

```
public class SelectProjectPageModel : FreshBasePageModel
{
    ....
    public ObservableCollection<Project> Projects { get; set; }
    public Project SelectedProject { get; set; }


   protected override async void ViewIsAppearing(object sender, EventArgs e)
   {
        if (!Projects.Any())
        {
            await PopulateProjects();
        }
    }

    public async Task PopulateProjects()
    {
        await _dataService.Pull<Project>();
        Projects = await _dataService.GetAllProjects();
        RaisePropertyChanged();
    }
}
```

The exception I get when navigating back and forth between my pages: 

> md52ce486a14f4bcd95899665e9d932190b.JavaProxyThrowable: System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. ---> System.AggregateException: One or more errors occurred. ---> System.NullReferenceException: Object reference not set to an instance of an object
> C:\Users\Michael\Documents\FreshEssentials\src\FreshEssentials\Controls\BindablePicker.cs, line 49
