### PR TITLE
Fixing: BindablePicker incorrectly nulls out SelectedItem after refreshing ItemsSource

### DIFF
--- a/src/FreshEssentials/Controls/AdvancedFrame.cs
+++ b/src/FreshEssentials/Controls/AdvancedFrame.cs
@@ -13,7 +13,7 @@ namespace FreshEssentials
 
     public class AdvancedFrame: Frame
     {
-        public static readonly BindableProperty InnerBackgroundProperty = BindableProperty.Create<AdvancedFrame, Color>(p => p.InnerBackground, default(Color));
+        public static readonly BindableProperty InnerBackgroundProperty = BindableProperty.Create("InnerBackground", typeof(Color), typeof(AdvancedFrame), default(Color));
 
         public Color InnerBackground
         {

--- a/src/FreshEssentials/Controls/BindablePicker.cs
+++ b/src/FreshEssentials/Controls/BindablePicker.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace FreshEssentials
 {
-    public class BindablePicker: Picker
+    public class BindablePicker : Picker
     {
         public BindablePicker()
         {
@@ -33,6 +33,7 @@ namespace FreshEssentials
         public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create("SelectedItem", typeof(object), typeof(BindablePicker), null, BindingMode.TwoWay, null, new BindableProperty.BindingPropertyChangedDelegate(BindablePicker.OnSelectedItemChanged), null, null, null);
         public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create("ItemsSource", typeof(IEnumerable), typeof(BindablePicker), null, BindingMode.OneWay, null, new BindableProperty.BindingPropertyChangedDelegate(BindablePicker.OnItemsSourceChanged), null, null, null);
         public static readonly BindableProperty DisplayPropertyProperty = BindableProperty.Create("DisplayProperty", typeof(string), typeof(BindablePicker), null, BindingMode.OneWay, null, new BindableProperty.BindingPropertyChangedDelegate(BindablePicker.OnDisplayPropertyChanged), null, null, null);
+        private bool disableEvents;
 
         public IList ItemsSource
         {
@@ -68,13 +69,15 @@ namespace FreshEssentials
 
         private void OnSelectedIndexChanged(object sender, EventArgs e)
         {
+            if (disableEvents) return;
+
             if (SelectedIndex == -1)
             {
                 this.SelectedItem = null;
             }
             else if (CanHaveAll && SelectedIndex == 0)
             {
-                this.SelectedItem = null;    
+                this.SelectedItem = null;
             }
             else
             {
@@ -139,6 +142,7 @@ namespace FreshEssentials
             BindablePicker picker = (BindablePicker)bindable;
             if (picker.ItemsSource as IEnumerable != null)
             {
+                picker.disableEvents = true;
                 picker.SelectedIndex = -1;
                 picker.Items.Clear();
                 int count = 0;
@@ -171,6 +175,7 @@ namespace FreshEssentials
                     }
                     count++;
                 }
+                picker.disableEvents = false;
             }
         }
     }

--- a/src/FreshEssentials/Controls/BindablePicker.cs
+++ b/src/FreshEssentials/Controls/BindablePicker.cs
@@ -46,13 +46,16 @@ namespace FreshEssentials
             set
             {
                 base.SetValue(BindablePicker.SelectedItemProperty, value);
-                if (ItemsSource.Contains(SelectedItem))
+                if (ItemsSource != null && SelectedItem != null)
                 {
-                    SelectedIndex = ItemsSource.IndexOf(SelectedItem);
-                }
-                else
-                {
-                    SelectedIndex = -1;
+                    if (ItemsSource.Contains(SelectedItem))
+                    {
+                        SelectedIndex = ItemsSource.IndexOf(SelectedItem);
+                    }
+                    else
+                    {
+                        SelectedIndex = -1;
+                    }
                 }
             }
         }

--- a/src/FreshEssentials/Controls/BindablePicker.cs
+++ b/src/FreshEssentials/Controls/BindablePicker.cs
@@ -14,7 +14,7 @@ namespace FreshEssentials
             base.SelectedIndexChanged += OnSelectedIndexChanged;
         }
 
-        public static readonly BindableProperty CanHaveAllProperty = BindableProperty.Create<BindablePicker, bool>(p => p.CanHaveAll, false);
+        public static readonly BindableProperty CanHaveAllProperty = BindableProperty.Create("CanHaveAll", typeof(bool), typeof(BindablePicker), false);
 
         public bool CanHaveAll
         {
@@ -22,7 +22,7 @@ namespace FreshEssentials
             set { SetValue(CanHaveAllProperty, value); }
         }
 
-        public static readonly BindableProperty AllTitleProperty = BindableProperty.Create<BindablePicker, string>(p => p.AllTitle, default(string));
+        public static readonly BindableProperty AllTitleProperty = BindableProperty.Create("AllTitle", typeof(string), typeof(BindablePicker), default(string));
 
         public string AllTitle
         {

--- a/src/FreshEssentials/Controls/SegmentedButton.cs
+++ b/src/FreshEssentials/Controls/SegmentedButton.cs
@@ -12,7 +12,7 @@ namespace FreshEssentials
 
     public class SegmentedButtonGroup : Grid
     {
-        public static readonly BindableProperty OnColorProperty = BindableProperty.Create<SegmentedButtonGroup, Color>(p => p.OnColor, Color.Blue);
+        public static readonly BindableProperty OnColorProperty = BindableProperty.Create("OnColor", typeof(Color), typeof(SegmentedButtonGroup), Color.Blue);
 
         public Color OnColor
         {
@@ -20,7 +20,7 @@ namespace FreshEssentials
             set { SetValue(OnColorProperty, value); }
         }
 
-        public static readonly BindableProperty OffColorProperty = BindableProperty.Create<SegmentedButtonGroup, Color>(p => p.OffColor, Color.White);
+        public static readonly BindableProperty OffColorProperty = BindableProperty.Create("OffColor", typeof(Color), typeof(SegmentedButtonGroup), Color.White);
 
         public Color OffColor
         {
@@ -28,7 +28,7 @@ namespace FreshEssentials
             set { SetValue(OffColorProperty, value); }
         }
 
-        public static readonly BindableProperty CommandProperty = BindableProperty.Create<SegmentedButtonGroup, Command>(p => p.Command, default(Command));
+        public static readonly BindableProperty CommandProperty = BindableProperty.Create("Command", typeof(Command), typeof(SegmentedButtonGroup), default(Command));
 
         public Command Command
         {
@@ -36,7 +36,7 @@ namespace FreshEssentials
             set { SetValue(CommandProperty, value); }
         }
 
-        public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create<SegmentedButtonGroup, int>(p => p.CornerRadius, 0);
+        public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create("CornerRadius", typeof(int), typeof(SegmentedButtonGroup), 0);
 
         public int CornerRadius
         {
@@ -50,12 +50,20 @@ namespace FreshEssentials
             internal set;
         }
 
-        public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create<SegmentedButtonGroup, int>(p => p.SelectedIndex, default(int));
+        public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create("SelectedIndex", typeof(int), typeof(SegmentedButtonGroup), default(int));
 
         public int SelectedIndex
         {
             get { return (int)GetValue(SelectedIndexProperty); }
             set { SetValue(SelectedIndexProperty, value); }
+        }
+
+        public static readonly BindableProperty FontSizeProperty = BindableProperty.Create("FontSize", typeof(string), typeof(SegmentedButtonGroup), "Small");
+
+        public string FontSize
+        {
+            get { return (string)GetValue(FontSizeProperty); }
+            set { SetValue(FontSizeProperty, value); }
         }
 
         public SegmentedButtonGroup()
@@ -98,10 +106,23 @@ namespace FreshEssentials
             {
                 var buttonSeg = SegmentedButtons[i];
 
+                double fontSize;    // local variable to save the interpreted font size
+                try
+                {
+                    // convert the normal names first
+                    fontSize = Device.GetNamedSize((NamedSize)Enum.Parse(typeof(NamedSize), FontSize, true), typeof(Label));
+                }
+                catch (Exception)
+                {
+                    // convert as a double and default if there is a problem
+                    if(double.TryParse(FontSize, out fontSize) == false)
+                        fontSize = Device.GetNamedSize(NamedSize.Default, typeof(Label));
+                }
+
                 var label = new Label
                 { 
                     Text = buttonSeg.Title, 
-                    FontSize = Device.GetNamedSize(NamedSize.Small, typeof(Label)), 
+                    FontSize = fontSize, 
                     HorizontalTextAlignment = TextAlignment.Center, 
                     VerticalTextAlignment = TextAlignment.Center 
                 };

--- a/src/FreshEssentials/Converters/HasDataConverter.cs
+++ b/src/FreshEssentials/Converters/HasDataConverter.cs
@@ -39,6 +39,7 @@ namespace FreshEssentials
     }
 }
 
+/*
 The MIT License (MIT)
 
 Copyright (c) 2014 James Montemagno / Refractored LLC
@@ -59,3 +60,5 @@ the Software, and to permit persons to whom the Software is furnished to do so,
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+    */


### PR DESCRIPTION
If ItemsSource on the picker is updated in a ViewModel, SelecteItem is incorrectly nulled out.
